### PR TITLE
fix: date values gone by transaction rollback

### DIFF
--- a/__tests__/transaction-api.test.ts
+++ b/__tests__/transaction-api.test.ts
@@ -25,7 +25,7 @@ describe("prisma.$transaction", () => {
       client.user.findMany({ where: { name: { contains: "Henk" } } }),
       client.user.count(),
     ]);
-  
+
     expect(henks[0].accountId).toEqual(1);
     expect(totalUsers).toEqual(2);
   });
@@ -70,5 +70,23 @@ describe("prisma.$transaction", () => {
 
     expect(allUsers).toHaveLength(3)
     expect(result).toEqual('success');
+  })
+
+  test("restore date values", async () => {
+    const client = createPrismaClient(data);
+
+    const original = await client.post.create({
+      data: {
+        title: 'Hello, world!',
+      }
+    });
+    try {
+      await client.$transaction(() => {
+        throw 'rollback';
+      });
+    } catch {}
+
+    const actual = await client.post.findFirst();
+    expect(JSON.stringify(original)).toBe(JSON.stringify(actual));
   })
 });

--- a/__tests__/utils/deepCopy.test.ts
+++ b/__tests__/utils/deepCopy.test.ts
@@ -1,0 +1,36 @@
+import { deepCopy } from "../../src/utils/deepCopy"
+
+describe('deepCopy', () => {
+  it('should copy primitive values', () => {
+    expect(deepCopy(42)).toBe(42);
+    expect(deepCopy('hello')).toBe('hello');
+    expect(deepCopy(true)).toBe(true);
+  });
+
+  it('should copy arrays', () => {
+    const arr = [1, 2, 3];
+    const copy = deepCopy(arr);
+    expect(copy).toEqual(arr);
+    expect(copy).not.toBe(arr);
+  });
+
+  it('should copy objects', () => {
+    const obj = { a: 1, b: { c: 2 } };
+    const copy = deepCopy(obj);
+    expect(copy).toEqual(obj);
+    expect(copy).not.toBe(obj);
+    expect(copy.b).not.toBe(obj.b);
+  });
+
+  it('should copy dates', () => {
+    const date = new Date();
+    const copy = deepCopy(date);
+    expect(copy).toEqual(date);
+    expect(copy).not.toBe(date);
+  });
+
+  it('should handle null and undefined', () => {
+    expect(deepCopy(null)).toBeNull();
+    expect(deepCopy(undefined)).toBeUndefined();
+  });
+});

--- a/__tests__/utils/deepEqual.test.ts
+++ b/__tests__/utils/deepEqual.test.ts
@@ -1,0 +1,58 @@
+import { deepEqual } from "../../src/utils/deepEqual"
+
+describe('deepEqual', () => {
+  test('should return true for identical objects', () => {
+    const obj1 = { a: 1, b: { c: 2 } };
+    const obj2 = { a: 1, b: { c: 2 } };
+    expect(deepEqual(obj1, obj2)).toBeTruthy();
+  });
+
+  test('should return false for different objects', () => {
+    const obj1 = { a: 1, b: { c: 2 } };
+    const obj2 = { a: 1, b: { c: 3 } };
+    expect(deepEqual(obj1, obj2)).toBeFalsy();
+  });
+
+  test('should return true for identical arrays', () => {
+    const arr1 = [1, 2, { a: 3 }];
+    const arr2 = [1, 2, { a: 3 }];
+    expect(deepEqual(arr1, arr2)).toBeTruthy();
+  });
+
+  test('should return false for different arrays', () => {
+    const arr1 = [1, 2, { a: 3 }];
+    const arr2 = [1, 2, { a: 4 }];
+    expect(deepEqual(arr1, arr2)).toBeFalsy();
+  });
+
+  test('should return true for identical primitive values', () => {
+    expect(deepEqual(1, 1)).toBeTruthy();
+    expect(deepEqual('test', 'test')).toBeTruthy();
+    expect(deepEqual(null, null)).toBeTruthy();
+    expect(deepEqual(undefined, undefined)).toBeTruthy();
+  });
+
+  test('should return false for different primitive values', () => {
+    expect(deepEqual(1, 2)).toBeFalsy();
+    expect(deepEqual('test', 'Test')).toBeFalsy();
+    expect(deepEqual(null, undefined)).toBeFalsy();
+  });
+
+  test('should return true for identical Date objects', () => {
+    const date1 = new Date('2023-01-01');
+    const date2 = new Date('2023-01-01');
+    expect(deepEqual(date1, date2)).toBeTruthy();
+  });
+
+  test('should return false for different Date objects', () => {
+    const date1 = new Date('2023-01-01');
+    const date2 = new Date('2024-01-01');
+    expect(deepEqual(date1, date2)).toBeFalsy();
+  });
+
+  test('should return false for Date and an object', () => {
+    const date1 = new Date('2023-01-01');
+    expect(deepEqual(date1, {})).toBeFalsy();
+    expect(deepEqual({}, date1)).toBeFalsy();
+  });
+});

--- a/lib/utils/deepCopy.js
+++ b/lib/utils/deepCopy.js
@@ -9,6 +9,9 @@ function deepCopy(source) {
     else if (Array.isArray(source)) {
         return source.map(deepCopy);
     }
+    else if (source instanceof Date) {
+        return new Date(source);
+    }
     return Object.fromEntries(Object.entries(source).map(([k, v]) => ([k, deepCopy(v)])));
 }
 exports.deepCopy = deepCopy;

--- a/lib/utils/deepEqual.js
+++ b/lib/utils/deepEqual.js
@@ -3,8 +3,20 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.deepEqual = void 0;
 // deepEqual
 function deepEqual(a, b) {
-    if ((typeof a == 'object' && a != null) &&
-        (typeof b == 'object' && b != null)) {
+    if (a === b) {
+        return true;
+    }
+    if ((typeof a === 'object' && a !== null) &&
+        (typeof b === 'object' && b !== null)) {
+        if (a instanceof Date) {
+            if (b instanceof Date) {
+                return a.getTime() === b.getTime();
+            }
+            return false;
+        }
+        else if (b instanceof Date) {
+            return false;
+        }
         var count = [0, 0];
         for (var key in a)
             count[0]++;
@@ -25,6 +37,6 @@ function deepEqual(a, b) {
         }
         return true;
     }
-    return a === b;
+    return false;
 }
 exports.deepEqual = deepEqual;

--- a/src/utils/deepCopy.ts
+++ b/src/utils/deepCopy.ts
@@ -6,6 +6,9 @@ export function deepCopy<T>(source:T): T {
   } else if (Array.isArray(source))
   {
     return source.map(deepCopy) as T
+  } else if (source instanceof Date)
+  {
+    return new Date(source) as unknown as T
   }
 
   return Object.fromEntries(Object.entries(source).map(([k,v]) => ([k, deepCopy(v)]))) as T

--- a/src/utils/deepEqual.ts
+++ b/src/utils/deepEqual.ts
@@ -1,9 +1,21 @@
 
 
 // deepEqual
-export function deepEqual(a: any, b: any) {
-  if ((typeof a == 'object' && a != null) &&
-    (typeof b == 'object' && b != null)) {
+export function deepEqual(a: any, b: any): boolean {
+  if (a === b) {
+    return true;
+  }
+  if ((typeof a === 'object' && a !== null) &&
+    (typeof b === 'object' && b !== null)) {
+    if (a instanceof Date) {
+      if (b instanceof Date) {
+        return a.getTime() === b.getTime();
+      }
+      return false;
+    } else if (b instanceof Date) {
+      return false;
+    }
+
     var count = [0, 0]
     for (var key in a) count[0]++
     for (var key in b) count[1]++
@@ -16,5 +28,5 @@ export function deepEqual(a: any, b: any) {
     }
     return true
   }
-  return a === b
+  return false;
 }


### PR DESCRIPTION
I encountered a bug during transaction rollback where values in the Date column could not be restored.
Date instances are always converted into empty objects ({}).
Upon investigation, it turned out there was an issue with deepCopy.

[Improvements]
* [`src/utils/deepCopy.ts`](diffhunk://#diff-6bd9378a3a6d1809323548e568cf0a87df156e9ab6241aa8f2ba4c48a1aa8ec3R9-R11): Updated TypeScript implementation to handle `Date` objects.
* [`src/utils/deepEqual.ts`](diffhunk://#diff-bea94e06b2ad3c3c24fca72091051a3818332c123584e5a6736d095b594974adL4-R18): Updated TypeScript implementation to handle `Date` objects and added type annotations. [[1]](diffhunk://#diff-bea94e06b2ad3c3c24fca72091051a3818332c123584e5a6736d095b594974adL4-R18) [[2]](diffhunk://#diff-bea94e06b2ad3c3c24fca72091051a3818332c123584e5a6736d095b594974adL19-R31)

New tests:

* [`__tests__/transaction-api.test.ts`](diffhunk://#diff-560a4b4280a4b8e12dc70c9e03dc495519231bf06a20c809feb461c4ebd2a0cbR74-R91): Added a test to verify that date values are restored correctly after a transaction rollback.
* [`__tests__/utils/deepCopy.test.ts`](diffhunk://#diff-2a9515a40527893ed60129e1635ef18f5113f7557b1eb8731f4038e8f217c640R1-R36): Added comprehensive tests for the `deepCopy` function, including tests for primitive values, arrays, objects, dates, and handling of `null` and `undefined`.
* [`__tests__/utils/deepEqual.test.ts`](diffhunk://#diff-dfd33a20b8afbe37a2863b48fe0ebd770df9aa37c1ce79577d72a8bd41068e4eR1-R58): Added comprehensive tests for the `deepEqual` function, including tests for objects, arrays, primitive values, and `Date` objects.